### PR TITLE
Theme song playback support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
  - [MajMongoose](https://github.com/majmongoose)
  - [Olaren15](https://github.com/Olaren15)
  - [dtrexler](https://github.com/dtrexler)
+ - [mehrmoudi](https://github.com/mehrmoudi)
 
 # Emby Contributors
 

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/themesong/ThemeSongPlayer.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/themesong/ThemeSongPlayer.kt
@@ -1,0 +1,62 @@
+package org.jellyfin.androidtv.data.service.themesong
+
+import android.content.Context
+import androidx.annotation.MainThread
+import org.jellyfin.androidtv.ui.playback.rewrite.RewriteMediaManager
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.ExtraType
+import java.util.UUID
+
+/**
+ * Handles playing and stopping theme songs upon request. Not all play requests result in actual playback. Specifically, there will be no
+ * playback if:
+ * - Another audio media (that doesn't have the [ExtraType.THEME_SONG] type) is queued or currently playing.
+ * - There are multiple sequential play requests for the same theme. Only the first request is honoured. Subsequent play requests for the
+ *   same theme song will only work if a different theme song is played next, or if [stopThemeSong] is called.
+ */
+class ThemeSongPlayer(
+	private val context: Context,
+	private val mediaManager: RewriteMediaManager
+) {
+	private var allowedToPlay = false
+	private var lastPlayedThemeSongUuid: UUID? = null
+
+	fun prepareForPlay() {
+		allowedToPlay = true
+	}
+
+	@MainThread
+	fun playThemeSong(themeSong: BaseItemDto?) {
+		if (nonThemeMusicPlayingOrQueued())
+			return
+
+		// Item doesn't have a theme song. Stop any already playing theme songs.
+		if (themeSong == null || themeSong.extraType != ExtraType.THEME_SONG) {
+			return stopThemeSong()
+		}
+
+		// Theme song is already playing or was the last thing played. Don't start it again.
+		if (lastPlayedThemeSongUuid == themeSong.id) {
+			return
+		}
+
+		if (allowedToPlay) {
+			lastPlayedThemeSongUuid = themeSong.id
+			mediaManager.playNow(context, listOf(themeSong), 0, false)
+		}
+	}
+
+	@MainThread
+	fun stopThemeSong() {
+		allowedToPlay = false
+		lastPlayedThemeSongUuid = null
+		if (mediaManager.currentAudioItem?.extraType == ExtraType.THEME_SONG)
+			mediaManager.stopAudio(true)
+	}
+
+	private fun nonThemeMusicPlayingOrQueued(): Boolean {
+		return ((mediaManager.isPlayingAudio && mediaManager.currentAudioItem?.extraType != ExtraType.THEME_SONG) ||
+			(!mediaManager.isPlayingAudio && mediaManager.hasAudioQueueItems()))
+	}
+
+}

--- a/app/src/main/java/org/jellyfin/androidtv/data/service/themesong/ThemeSongService.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/data/service/themesong/ThemeSongService.kt
@@ -1,0 +1,107 @@
+package org.jellyfin.androidtv.data.service.themesong
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jellyfin.androidtv.auth.repository.UserRepository
+import org.jellyfin.androidtv.preference.UserPreferences
+import org.jellyfin.androidtv.ui.playback.AudioEventListener
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.libraryApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.BaseItemKind
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Handles theme song playing on notification from navigation in various item pages.
+ *
+ * - When an item page is requested, cancels any previous delayed playback stop requests.
+ * - When an item page is displayed, fetches and caches the theme song, then passes it to [ThemeSongPlayer].
+ * - When an item page is closed, first ensures we're not waiting for a item page to be displayed. If not, schedules a delayed playback
+ * stop job. If a new item details opens in the meanwhile, the stop request is cancelled.
+ */
+class ThemeSongService(
+	private val api: ApiClient,
+	private val userPreferences: UserPreferences,
+	private val userRepository: UserRepository,
+	private val themeSongPlayer: ThemeSongPlayer,
+) : AudioEventListener {
+
+	/**
+	 * Keeps track of the state of the current item page.
+	 */
+	enum class ItemPageState {
+		REQUESTED, // Item page was requested to launch, but it hasn't been displayed yet.
+		DISPLAYED, // Item page is being displayed.
+		HIDDEN // Item page was closed.
+	}
+
+	private val scope = MainScope()
+	private val itemToThemeSongCache = mutableMapOf<UUID, BaseItemDto>()
+	private val delayedStopDuration = 200.milliseconds
+	private var delayedThemeSongStopJob: Job? = null
+	private var itemPageState: ItemPageState = ItemPageState.HIDDEN
+
+	/**
+	 * Called when a new item page was requested and is about to be displayed.
+	 */
+	fun itemPageRequested() {
+		itemPageState = ItemPageState.REQUESTED
+		// Cancel any previously scheduled stops. If needed, we will stop when [itemPageDisplayed] is called.
+		// This is mainly to continue playing when navigating between items with same theme songs.
+		delayedThemeSongStopJob?.cancel()
+	}
+
+	/**
+	 * Called when a new item page is displayed.
+	 */
+	fun itemPageDisplayed(baseItem: BaseItemDto?) {
+		itemPageState = ItemPageState.DISPLAYED
+		// Cancel any previously scheduled stops. If needed, we will stop further down.
+		// This is mainly to continue playing when navigating between items with same theme songs.
+		delayedThemeSongStopJob?.cancel()
+		val currentUserId = userRepository.currentUser.value?.id
+		if (currentUserId == null || !userPreferences[UserPreferences.themeSongsEnabled]) return themeSongPlayer.stopThemeSong()
+
+		if (baseItem?.type == BaseItemKind.PERSON) {
+			// No need to interrupt the playback if a person page is showed.
+			return
+		}
+
+		if (baseItem == null) return themeSongPlayer.stopThemeSong()
+
+		themeSongPlayer.prepareForPlay()
+		scope.launch(Dispatchers.IO) {
+			loadAndPlayThemeSong(baseItem.id, currentUserId)
+		}
+	}
+
+	/**
+	 * Called when an item page is getting hidden, either by a closing or another page showing on top.
+	 */
+	fun itemPageHidden() {
+		if (itemPageState == ItemPageState.REQUESTED) {
+			// [itemPageHidden] was called because a newly requested item page is going to be displayed on top.
+			// Don't take any action now. We'll decide what to do when the new item page is displayed.
+			return
+		}
+		itemPageState = ItemPageState.HIDDEN
+		delayedThemeSongStopJob?.cancel()
+		delayedThemeSongStopJob = scope.launch(Dispatchers.Main) {
+			// Don't immediately stop the theme song in case we navigated to another item page with the same song.
+			delay(delayedStopDuration)
+			themeSongPlayer.stopThemeSong()
+		}
+	}
+
+	private suspend fun loadAndPlayThemeSong(itemId: UUID, userId: UUID) {
+		if (!itemToThemeSongCache.contains(itemId)) {
+			val loadedThemeSong = api.libraryApi.getThemeSongs(itemId, userId, true).content.items.firstOrNull()
+			if (loadedThemeSong != null) itemToThemeSongCache[itemId] = loadedThemeSong
+		}
+		scope.launch(Dispatchers.Main) { themeSongPlayer.playThemeSong(itemToThemeSongCache[itemId]) }
+	}
+}

--- a/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/AppModule.kt
@@ -25,6 +25,8 @@ import org.jellyfin.androidtv.data.repository.NotificationsRepositoryImpl
 import org.jellyfin.androidtv.data.repository.UserViewsRepository
 import org.jellyfin.androidtv.data.repository.UserViewsRepositoryImpl
 import org.jellyfin.androidtv.data.service.BackgroundService
+import org.jellyfin.androidtv.data.service.themesong.ThemeSongPlayer
+import org.jellyfin.androidtv.data.service.themesong.ThemeSongService
 import org.jellyfin.androidtv.integration.dream.DreamViewModel
 import org.jellyfin.androidtv.ui.ScreensaverViewModel
 import org.jellyfin.androidtv.ui.itemhandling.ItemLauncher
@@ -126,6 +128,8 @@ val appModule = module {
 	viewModel { DreamViewModel(get(), get(), get(), get(), get()) }
 
 	single { BackgroundService(get(), get(), get(), get(), get()) }
+	single { ThemeSongPlayer(get(), get()) }
+	single { ThemeSongService(get(), get(), get(), get()) }
 
 	single { MarkdownRenderer(get()) }
 	single { ItemLauncher() }

--- a/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/di/PlaybackModule.kt
@@ -36,7 +36,8 @@ import org.jellyfin.androidtv.ui.playback.PlaybackManager as LegacyPlaybackManag
 val playbackModule = module {
 	single { LegacyPlaybackManager(get()) }
 	single { VideoQueueManager() }
-	single<MediaManager> { RewriteMediaManager(get(), get(), get(), get()) }
+	single { RewriteMediaManager(get(), get(), get(), get()) }
+	single<MediaManager> { get() as RewriteMediaManager }
 
 	single { PlaybackLauncher(get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/preference/UserPreferences.kt
@@ -45,6 +45,11 @@ class UserPreferences(context: Context) : SharedPreferenceStore(
 		var backdropEnabled = booleanPreference("pref_show_backdrop", true)
 
 		/**
+		 * Enable theme songs while browsing
+		 */
+		var themeSongsEnabled = booleanPreference("pref_play_theme_songs", true)
+
+		/**
 		 * Show premieres on home screen
 		 */
 		var premieresEnabled = booleanPreference("pref_enable_premieres", false)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/NowPlayingView.kt
@@ -51,6 +51,7 @@ import org.jellyfin.playback.core.PlaybackManager
 import org.jellyfin.playback.jellyfin.queue.baseItem
 import org.jellyfin.playback.jellyfin.queue.baseItemFlow
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.model.api.ExtraType
 import org.jellyfin.sdk.model.api.ImageType
 import org.koin.compose.koinInject
 
@@ -72,7 +73,7 @@ fun NowPlayingComposable(
 		targetState = item,
 		transitionSpec = { fadeIn() togetherWith fadeOut() },
 	) { item ->
-		if (item != null) {
+		if (item != null && item.extraType != ExtraType.THEME_SONG) {
 			ButtonBase(
 				onClick = { navigationRepository.navigate(Destinations.nowPlaying) },
 				shape = JellyfinTheme.shapes.extraSmall,

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -37,6 +37,7 @@ import org.jellyfin.androidtv.data.model.DataRefreshService;
 import org.jellyfin.androidtv.data.querying.GetUserViewsRequest;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
 import org.jellyfin.androidtv.data.service.BackgroundService;
+import org.jellyfin.androidtv.data.service.themesong.ThemeSongService;
 import org.jellyfin.androidtv.databinding.EnhancedDetailBrowseBinding;
 import org.jellyfin.androidtv.ui.GridButton;
 import org.jellyfin.androidtv.ui.itemhandling.BaseRowItem;
@@ -97,6 +98,7 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
     protected ListRow mCurrentRow;
 
     private Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
+
     private Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
     private final Lazy<NavigationRepository> navigationRepository = inject(NavigationRepository.class);

--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/GenericFolderFragment.kt
@@ -3,13 +3,17 @@ package org.jellyfin.androidtv.ui.browsing
 import org.jellyfin.androidtv.R
 import org.jellyfin.androidtv.data.querying.GetSpecialsRequest
 import org.jellyfin.androidtv.data.repository.ItemRepository
+import org.jellyfin.androidtv.data.service.themesong.ThemeSongService
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ItemFilter
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
+import org.koin.android.ext.android.inject
 
 class GenericFolderFragment : EnhancedBrowseFragment() {
+	private val themeSongService: ThemeSongService by inject()
+
 	companion object {
 		private val showSpecialViewTypes = setOf(
 			BaseItemKind.COLLECTION_FOLDER,
@@ -17,6 +21,11 @@ class GenericFolderFragment : EnhancedBrowseFragment() {
 			BaseItemKind.USER_VIEW,
 			BaseItemKind.CHANNEL_FOLDER_ITEM,
 		)
+	}
+
+	override fun onStop() {
+		super.onStop()
+		themeSongService.itemPageHidden()
 	}
 
 	override fun setupQueries(rowLoader: RowLoader) {
@@ -66,6 +75,7 @@ class GenericFolderFragment : EnhancedBrowseFragment() {
 		if (mFolder.type == BaseItemKind.SEASON) {
 			val specials = GetSpecialsRequest(mFolder.id)
 			mRows.add(BrowseRowDef(getString(R.string.lbl_specials), specials))
+			themeSongService.itemPageDisplayed(mFolder)
 		}
 
 		rowLoader.loadRows(mRows)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemdetail/FullDetailsFragment.java
@@ -46,6 +46,7 @@ import org.jellyfin.androidtv.data.querying.GetSpecialsRequest;
 import org.jellyfin.androidtv.data.querying.GetTrailersRequest;
 import org.jellyfin.androidtv.data.repository.CustomMessageRepository;
 import org.jellyfin.androidtv.data.service.BackgroundService;
+import org.jellyfin.androidtv.data.service.themesong.ThemeSongService;
 import org.jellyfin.androidtv.databinding.FragmentFullDetailsBinding;
 import org.jellyfin.androidtv.preference.UserPreferences;
 import org.jellyfin.androidtv.preference.constant.ClockBehavior;
@@ -142,6 +143,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     private final Lazy<UserPreferences> userPreferences = inject(UserPreferences.class);
     private final Lazy<DataRefreshService> dataRefreshService = inject(DataRefreshService.class);
     private final Lazy<BackgroundService> backgroundService = inject(BackgroundService.class);
+    private final Lazy<ThemeSongService> themeSongService = inject(ThemeSongService.class);
     final Lazy<MediaManager> mediaManager = inject(MediaManager.class);
     private final Lazy<MarkdownRenderer> markdownRenderer = inject(MarkdownRenderer.class);
     private final Lazy<CustomMessageRepository> customMessageRepository = inject(CustomMessageRepository.class);
@@ -286,6 +288,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
     public void onStop() {
         super.onStop();
         stopClock();
+        themeSongService.getValue().itemPageHidden();
     }
 
     @Override
@@ -487,6 +490,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
         mBaseItem = item;
         backgroundService.getValue().setBackground(item);
+        themeSongService.getValue().itemPageDisplayed(item);
         if (mBaseItem != null) {
             if (mChannelId != null) {
                 mBaseItem = JavaCompat.copyWithParentId(mBaseItem, mChannelId);
@@ -581,7 +585,7 @@ public class FullDetailsFragment extends Fragment implements RecordingIndicatorV
 
                 break;
             case MUSIC_ARTIST:
-                ItemRowAdapter artistAlbumsAdapter = new ItemRowAdapter(requireContext(),  BrowsingUtils.createArtistItemsRequest(mBaseItem.getId(), BaseItemKind.MUSIC_ALBUM), 100, false, new CardPresenter(), adapter);
+                ItemRowAdapter artistAlbumsAdapter = new ItemRowAdapter(requireContext(), BrowsingUtils.createArtistItemsRequest(mBaseItem.getId(), BaseItemKind.MUSIC_ALBUM), 100, false, new CardPresenter(), adapter);
                 addItemRow(adapter, artistAlbumsAdapter, 0, getString(R.string.lbl_albums));
 
                 break;

--- a/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/itemhandling/ItemLauncher.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import org.jellyfin.androidtv.constant.LiveTvOption;
 import org.jellyfin.androidtv.constant.QueryType;
 import org.jellyfin.androidtv.data.model.ChapterItemInfo;
+import org.jellyfin.androidtv.data.service.themesong.ThemeSongService;
 import org.jellyfin.androidtv.preference.LibraryPreferences;
 import org.jellyfin.androidtv.preference.PreferencesRepository;
 import org.jellyfin.androidtv.ui.navigation.Destination;
@@ -36,6 +37,7 @@ public class ItemLauncher {
     private final Lazy<MediaManager> mediaManager = KoinJavaComponent.<MediaManager>inject(MediaManager.class);
     private final Lazy<PlaybackLauncher> playbackLauncher = KoinJavaComponent.<PlaybackLauncher>inject(PlaybackLauncher.class);
     private final Lazy<PlaybackHelper> playbackHelper = KoinJavaComponent.<PlaybackHelper>inject(PlaybackHelper.class);
+    private final Lazy<ThemeSongService> themeSongService = KoinJavaComponent.<ThemeSongService>inject(ThemeSongService.class);
 
     public void launchUserView(@Nullable final BaseItemDto baseItem) {
         Timber.d("**** Collection type: %s", baseItem.getCollectionType());
@@ -66,6 +68,7 @@ public class ItemLauncher {
     }
 
     public void launch(final BaseRowItem rowItem, ItemRowAdapter adapter, final Context context) {
+        themeSongService.getValue().itemPageRequested();
         switch (rowItem.getBaseRowType()) {
             case BaseItem:
                 BaseItemDto baseItem = rowItem.getBaseItem();
@@ -74,7 +77,6 @@ public class ItemLauncher {
                 } catch (Exception e) {
                     //swallow it
                 }
-
                 //specialized type handling
                 switch (baseItem.getType()) {
                     case USER_VIEW:

--- a/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/preference/screen/CustomizationPreferencesScreen.kt
@@ -49,6 +49,12 @@ class CustomizationPreferencesScreen : OptionsFragment() {
 			}
 
 			checkbox {
+				setTitle(R.string.lbl_play_theme_songs)
+				setContent(R.string.pref_play_theme_songs_description)
+				bind(userPreferences, UserPreferences.themeSongsEnabled)
+			}
+
+			checkbox {
 				setTitle(R.string.lbl_use_series_thumbnails)
 				setContent(R.string.lbl_use_series_thumbnails_description)
 				bind(userPreferences, UserPreferences.seriesThumbnailsEnabled)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,6 +195,8 @@
     <string name="lbl_open">Open</string>
     <string name="lbl_show_backdrop">Show backdrops</string>
     <string name="pref_show_backdrop_description">Change background image to selected items</string>
+    <string name="lbl_play_theme_songs">Play theme songs</string>
+    <string name="pref_play_theme_songs_description">Play theme songs in background while browsing the library</string>
     <string name="lbl_show_premieres">Show season premieres</string>
     <string name="desc_premieres">Show a row of new episode pilots for any series you watch</string>
     <string name="lbl_in_x_days">In %d days</string>


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Adds theme song playback support using the `RewriteMediaManager` class. Behaviour:
- Upon navigating to an item that has a theme song, it starts playing in the background if there is no other media playing or queued.
- Further navigation to other items with the same theme song doesn't interrupt or restart the playback.
- Once playback finishes, it won't start again even when navigating back and forth between pages. However it will happen if if the user navigates to an item with a different theme song, or goes back to the home screen, and then comes back again. 

**Issues**
https://github.com/jellyfin/jellyfin-androidtv/issues/1150
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
